### PR TITLE
Fix markdown for configuration example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The addon attempts to get a list of available style guide versions from the root
 1. Include the addon in your `addons.js`
     - `import '@panosvoudouris/addon-versions/register';`
 1. Create the Versions config at `.storybook/storybook-config.json`
-    - ```{
+    - ```
+      {
         "storybook": {
           "versions": {
             "availableVersions": [


### PR DESCRIPTION
The opening bracket in this example code was getting eaten by markdown and wasn't appearing in the readme. Silly, but we actually got caught up on this for a bit when copy and pasting the example to set up the plugin.